### PR TITLE
Fix slope panel block not mirroring properly

### DIFF
--- a/src/main/java/xfacthd/framedblocks/common/block/slopepanel/FramedSlopePanelBlock.java
+++ b/src/main/java/xfacthd/framedblocks/common/block/slopepanel/FramedSlopePanelBlock.java
@@ -99,10 +99,10 @@ public class FramedSlopePanelBlock extends FramedBlock
 
     public static BlockState mirrorPanel(BlockState state, Mirror mirror)
     {
-        BlockState newState = Utils.mirrorFaceBlock(state, mirror);
+        state = Utils.mirrorFaceBlock(state, mirror);
 
         HorizontalRotation rot = state.getValue(PropertyHolder.ROTATION);
-        if (newState != state && !rot.isVertical())
+        if (mirror != Mirror.NONE && !rot.isVertical())
         {
             state = state.setValue(PropertyHolder.ROTATION, rot.getOpposite());
         }


### PR DESCRIPTION
While playing around FramedBlocks with Create Schematics, I found out that **Slope Panel Block** does not work properly when handling schematics mirror. Maybe this PR is a mistake, but it seems to work properly when playing around with modified code.

These are new behaviors for `mirrorPanel`, which I think should be right.
1. facing direction is parallel to mirror plane: do not rotate `FACING`, make `ROTATION` opposite.
2. facing direction is perpendicular to mirror plane: rotate `FACING`, make `ROTATION` opposite.

So, output from `Utils.mirrorFaceBlock` should be used, and whether `newState != state` is not relevant to `ROTATION`.