### PR TITLE
Convert 1.20.1 to MDG

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,7 @@ plugins {
     id 'eclipse'
     id 'idea'
     id 'maven-publish'
-    id 'net.neoforged.gradle' version '6.0.21'
-    id 'org.parchmentmc.librarian.forgegradle' version '1.2.0'
-    id 'org.spongepowered.mixin' version '0.7.38'
+    id 'net.neoforged.moddev.legacyforge' version '2.0.76'
 }
 
 version = mod_version
@@ -17,93 +15,62 @@ base {
 // Mojang ships Java 17 to end users in 1.18+, so your mod should target Java 17.
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
-jarJar.enable()
+legacyForge {
+    version = "1.20.1-47.1.3"
 
-println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty 'java.vm.version'} (${System.getProperty 'java.vendor'}), Arch: ${System.getProperty 'os.arch'}"
-minecraft {
-    mappings channel: 'parchment', version: "${mapping_version}-${minecraft_version}"
-
-    copyIdeResources = true
-
-    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
-
-    // Default run configurations.
-    // These can be tweaked, removed, or duplicated as needed.
     runs {
+        configureEach {
+            systemProperty 'forge.enabledGameTestNamespaces', 'framedblocks'
+            systemProperty 'terminal.ansi', 'true'
+
+            logLevel = org.slf4j.event.Level.DEBUG
+
+            sourceSet = project.sourceSets.test
+        }
+
         client {
-            workingDirectory project.file('run')
-
-            // Recommended logging data for a userdev environment
-            // property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-
-            // Recommended logging level for the console
-            property 'forge.logging.console.level', 'debug'
-
-            // Comma-separated list of namespaces to load gametests from. Empty = all namespaces.
-            property 'forge.enabledGameTestNamespaces', 'framedblocks'
-
-            mods {
-                framedblocks {
-                    source sourceSets.main
-                    source sourceSets.test
-                }
-            }
+            client()
+            gameDirectory = project.file('run')
         }
 
         server {
-            workingDirectory project.file('run_server')
+            server()
+            gameDirectory = project.file('run_server')
 
-            // Recommended logging data for a userdev environment
-            // property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-
-            // Recommended logging level for the console
-            property 'forge.logging.console.level', 'debug'
-
-            mods {
-                framedblocks {
-                    source sourceSets.main
-                    source sourceSets.test
-                }
-            }
+            programArgument '--nogui'
         }
 
         data {
-            workingDirectory project.file('run')
+            data()
+            gameDirectory = project.file('run')
 
-            // Recommended logging data for a userdev environment
-            // property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-
-            // Recommended logging level for the console
-            property 'forge.logging.console.level', 'debug'
-
-            args '--mod', 'framedblocks', '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
-
-            mods {
-                framedblocks {
-                    source sourceSets.main
-                }
-            }
+            programArguments.addAll(
+                    '--mod', 'framedblocks',
+                    '--all',
+                    '--output', file('src/generated/resources/').getAbsolutePath(),
+                    '--existing', file('src/main/resources/').getAbsolutePath(),
+                    '--existing-mod', 'ae2'
+            )
         }
 
         gameTestServer {
-            workingDirectory project.file('run_gametest')
-
-            // Recommended logging data for a userdev environment
-            // property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-
-            // Recommended logging level for the console
-            property 'forge.logging.console.level', 'debug'
-
-            // Comma-separated list of namespaces to load gametests from. Empty = all namespaces.
-            property 'forge.enabledGameTestNamespaces', 'framedblocks'
-
-            mods {
-                framedblocks {
-                    source sourceSets.main
-                    source sourceSets.test
-                }
-            }
+            type = "gameTestServer"
+            gameDirectory = project.file('run_gametest')
         }
+    }
+
+    mods {
+        framedblocks {
+            sourceSet sourceSets.main
+            sourceSet sourceSets.test
+        }
+    }
+
+    addModdingDependenciesTo(project.sourceSets.test)
+
+    parchment {
+        minecraftVersion = "${minecraft_version}"
+        mappingsVersion = "${mapping_version}"
     }
 }
 
@@ -168,81 +135,83 @@ repositories {
 }
 
 dependencies {
-    minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
+    modCompileOnly "team.chisel.ctm:CTM:1.20.1-1.1.8+4"
 
-    compileOnly fg.deobf("team.chisel.ctm:CTM:1.20.1-1.1.8+4")
+    //modRuntimeOnly "curse.maven:puzzleslib-495476:4621178" //Only needed when Diagonal Fences or Diagonal Windows is switched to implementation
+    modCompileOnly "curse.maven:diagonalfences-458048:4611775"
+    modCompileOnly "curse.maven:diagonalwindows-891328:4660584"
 
-    //runtimeOnly fg.deobf("curse.maven:puzzleslib-495476:4621178") //Only needed when Diagonal Fences or Diagonal Windows is switched to implementation
-    compileOnly fg.deobf("curse.maven:diagonalfences-458048:4611775")
-    compileOnly fg.deobf("curse.maven:diagonalwindows-891328:4660584")
+    modCompileOnly "curse.maven:buildinggadgets-298187:3829297"
 
-    compileOnly fg.deobf("curse.maven:buildinggadgets-298187:3829297")
+    modCompileOnly ("xfacthd.contex:ConnectedTextures:2.1:slim") { transitive = false }
 
-    implementation fg.deobf("xfacthd.contex:ConnectedTextures:2.1:slim") { transitive = false }
+    modImplementation "curse.maven:athena-841890:5176879"
+    //modRuntimeOnly "curse.maven:resfullib-570073:5210240"
+    //modRuntimeOnly "curse.maven:chipped-456956:5270039"
 
-    implementation fg.deobf("curse.maven:athena-841890:5176879")
-    //runtimeOnly fg.deobf("curse.maven:resfullib-570073:5210240")
-    //runtimeOnly fg.deobf("curse.maven:chipped-456956:5270039")
+    modCompileOnly "curse.maven:xycraft_core-653786:4788862"
+    modCompileOnly "curse.maven:xycraft_world-653789:4788863"
 
-    compileOnly fg.deobf("curse.maven:xycraft_core-653786:4788862")
-    compileOnly fg.deobf("curse.maven:xycraft_world-653789:4788863")
-
-    compileOnly(fg.deobf("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"))
-    compileOnly(fg.deobf("mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}"))
-    //runtimeOnly(fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}"))
+    modCompileOnly "mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"
+    modCompileOnly "mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}"
+    //modRuntimeOnly "mezz.jei:jei-${minecraft_version}-forge:${jei_version}"
 
     // Switch Arch, Cloth and REI-forge to impl for runtime testing
-    compileOnly fg.deobf("dev.architectury:architectury-forge:${arch_version}")
-    compileOnly fg.deobf("me.shedaniel.cloth:cloth-config-forge:${cloth_version}")
-    compileOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-forge:${rei_version}")
-    //runtimeOnly fg.deobf("curse.maven:reipc-521393:4723408")
-    compileOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-api-forge:${rei_version}")
-    compileOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-default-plugin-forge:${rei_version}")
-    compileOnly fg.deobf("me.shedaniel:REIPluginCompatibilities-forge-annotations:${reipcanno_version}")
+    modCompileOnly "dev.architectury:architectury-forge:${arch_version}"
+    modCompileOnly "me.shedaniel.cloth:cloth-config-forge:${cloth_version}"
+    modCompileOnly "me.shedaniel:RoughlyEnoughItems-forge:${rei_version}"
+    //modRuntimeOnly "curse.maven:reipc-521393:4723408"
+    modCompileOnly "me.shedaniel:RoughlyEnoughItems-api-forge:${rei_version}"
+    modCompileOnly "me.shedaniel:RoughlyEnoughItems-default-plugin-forge:${rei_version}"
+    modCompileOnly "me.shedaniel:REIPluginCompatibilities-forge-annotations:${reipcanno_version}"
 
-    compileOnly fg.deobf("dev.emi:emi-forge:${emi_version}+${minecraft_version}:api")
-    runtimeOnly fg.deobf("dev.emi:emi-forge:${emi_version}+${minecraft_version}")
+    modCompileOnly "dev.emi:emi-forge:${emi_version}+${minecraft_version}:api"
+    modRuntimeOnly "dev.emi:emi-forge:${emi_version}+${minecraft_version}"
 
-    //runtimeOnly fg.deobf("curse.maven:spark-361579:3767286")
+    //modRuntimeOnly "curse.maven:spark-361579:3767286"
 
-    //runtimeOnly fg.deobf("curse.maven:rubidium-574856:4684247")
-    //runtimeOnly fg.deobf("org.embeddedt:embeddium-${embeddium_mc_version}:${embeddium_version}+mc${embeddium_mc_version}")
-    //runtimeOnly fg.deobf("curse.maven:oculus-581495:5299671")
-    //runtimeOnly fg.deobf("curse.maven:starlight-forge-526854:4631193")
+    //modRuntimeOnly "curse.maven:rubidium-574856:4684247"
+    //modRuntimeOnly "org.embeddedt:embeddium-${embeddium_mc_version}:${embeddium_version}+mc${embeddium_mc_version}"
+    //modRuntimeOnly "curse.maven:oculus-581495:5299671"
+    //modRuntimeOnly "curse.maven:starlight-forge-526854:4631193"
 
-    compileOnly fg.deobf("com.simibubi.create:create-${create_mc_version}:${create_version}-${create_build_number}:slim") { transitive = false }
-    compileOnly fg.deobf("net.createmod.ponder:Ponder-Forge-${create_mc_version}:${ponder_version}")
-    compileOnly fg.deobf("dev.engine-room.flywheel:flywheel-forge-api-${create_mc_version}:${flywheel_version}-${flywheel_build_number}")
+    modCompileOnly ("com.simibubi.create:create-${create_mc_version}:${create_version}-${create_build_number}:slim") { transitive = false }
+    modCompileOnly "net.createmod.ponder:Ponder-Forge-${create_mc_version}:${ponder_version}"
+    modCompileOnly "dev.engine-room.flywheel:flywheel-forge-api-${create_mc_version}:${flywheel_version}-${flywheel_build_number}"
     // Only needed when Create and Ponder are switched to implementation
-    //runtimeOnly fg.deobf("dev.engine-room.flywheel:flywheel-forge-${create_mc_version}:${flywheel_version}-${flywheel_build_number}")
-    //runtimeOnly fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
+    //modRuntimeOnly "dev.engine-room.flywheel:flywheel-forge-${create_mc_version}:${flywheel_version}-${flywheel_build_number}"
+    //modRuntimeOnly "com.tterrag.registrate:Registrate:${registrate_version}"
 
-    compileOnly fg.deobf("curse.maven:moonlight-499980:4621773")
-    compileOnly fg.deobf("curse.maven:supplementaries-412082:4622527")
+    modCompileOnly "curse.maven:moonlight-499980:4621773"
+    modCompileOnly "curse.maven:supplementaries-412082:4622527"
 
-    //runtimeOnly fg.deobf("curse.maven:corelib-454372:4927036")
-    //runtimeOnly fg.deobf("curse.maven:fusion-854949:5005130")
-    //runtimeOnly fg.deobf("curse.maven:conglass-383129:5002550")
+    //modRuntimeOnly "curse.maven:corelib-454372:4927036"
+    //modRuntimeOnly "curse.maven:fusion-854949:5005130"
+    //modRuntimeOnly "curse.maven:conglass-383129:5002550"
 
-    compileOnly fg.deobf("curse.maven:nocubes-309664:3944569")
+    modCompileOnly "curse.maven:nocubes-309664:3944569"
 
-    implementation fg.deobf("curse.maven:guidebook-253874:4593765")
+    modImplementation "curse.maven:guidebook-253874:4593765"
 
-    compileOnly fg.deobf("curse.maven:jade-324717:5072729")
+    modCompileOnly "curse.maven:jade-324717:5072729"
 
-    compileOnly fg.deobf("curse.maven:atlasviewer-633577:4762356")
+    modCompileOnly "curse.maven:atlasviewer-633577:4762356"
 
-    minecraftLibrary(group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.1.1')
-    jarJar(group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '[3.1.1,4.0.0)') {
+    additionalRuntimeClasspath(group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.1.1')
+    jarJar(implementation(group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.1.1')) {
         transitive(false)
     }
 
     implementation(annotationProcessor("io.github.llamalad7:mixinextras-common:0.2.0-rc.4"))
-    implementation(jarJar("io.github.llamalad7:mixinextras-forge:0.2.0-rc.4")) {
-        jarJar.ranged(it, "[0.2.0-rc.4,)")
+    jarJar(implementation("io.github.llamalad7:mixinextras-forge:0.2.0-rc.4")) {
+        version {
+            strictly '[0.2.0-rc.4,)'
+            prefer '0.2.0-rc.4'
+        }
     }
 
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+    compileOnly 'org.jetbrains:annotations:26.0.1' // Needed because MDG legacy doesn't inject it automatically
 }
 
 mixin {
@@ -276,14 +245,8 @@ processTestResources {
     duplicatesStrategy(DuplicatesStrategy.INCLUDE)
 }
 
-tasks.jarJar.configure {
-    archiveClassifier = ''
-}
-
 // Example for how to get properties into the manifest for reading by the runtime..
 tasks.named('jar', Jar).configure {
-    archiveClassifier = 'slim'
-
     manifest {
         attributes([
                 "Specification-Title"     : "framedblocks",
@@ -291,7 +254,8 @@ tasks.named('jar', Jar).configure {
                 "Specification-Version"   : "1", // We are version 1 of ourselves
                 "Implementation-Title"    : project.name,
                 "Implementation-Version"  : project.jar.archiveVersion,
-                "Implementation-Vendor"   : "XFactHD"
+                "Implementation-Vendor"   : "XFactHD",
+                "MixinConfigs"            : "framedblocks.mixin.json"
         ])
     }
 
@@ -299,10 +263,6 @@ tasks.named('jar', Jar).configure {
     // More information at https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives
     preserveFileTimestamps = false
     reproducibleFileOrder = true
-
-    // Example configuration to allow publishing using the maven-publish plugin
-    // This is the preferred method to reobfuscate your jar file
-    finalizedBy('reobfJar')
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'eclipse'
     id 'idea'
     id 'maven-publish'
-    id 'net.neoforged.moddev.legacyforge' version '2.0.76'
+    id 'net.neoforged.moddev.legacyforge' version '2.0.79'
 }
 
 version = mod_version
@@ -143,7 +143,7 @@ dependencies {
 
     modCompileOnly "curse.maven:buildinggadgets-298187:3829297"
 
-    modCompileOnly ("xfacthd.contex:ConnectedTextures:2.1:slim") { transitive = false }
+    modImplementation ("xfacthd.contex:ConnectedTextures:2.1:slim") { transitive = false }
 
     modImplementation "curse.maven:athena-841890:5176879"
     //modRuntimeOnly "curse.maven:resfullib-570073:5210240"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Self-explanatory. Client, datagen, and gametest server runs all work fine. Running in prod on a client also works fine. The only issue I encountered is ConTex refusing to deobfuscate properly with MDG for some reason, so I just swapped it to `modCompileOnly` for now (I doubt this is a dealbreaker, given how old 1.20 is now).

Hope it helps, but no pressure to accept.