### PR TITLE
Implemented Rotation for Collapsible blocks

### DIFF
--- a/src/main/java/xfacthd/framedblocks/common/block/cube/FramedCollapsibleBlock.java
+++ b/src/main/java/xfacthd/framedblocks/common/block/cube/FramedCollapsibleBlock.java
@@ -1,8 +1,11 @@
 package xfacthd.framedblocks.common.block.cube;
 
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.Mth;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.ItemInteractionResult;
@@ -19,8 +22,10 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.*;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xfacthd.framedblocks.FramedBlocks;
 import xfacthd.framedblocks.api.block.FramedProperties;
 import xfacthd.framedblocks.api.block.PlacementStateBuilder;
 import xfacthd.framedblocks.api.shapes.ShapeUtils;
@@ -47,13 +52,14 @@ public class FramedCollapsibleBlock extends FramedBlock
                 .setValue(PropertyHolder.ROTATE_SPLIT_LINE, false)
         );
     }
+
+
+
     @Override
-    protected @NotNull BlockState rotate(BlockState state, Rotation rot)
-    {
+    protected @NotNull BlockState rotate(@NotNull BlockState state, @NotNull Rotation rotation) {
         Direction nullableDirection = state.getValue(PropertyHolder.NULLABLE_FACE).toDirection();
         if(nullableDirection != null)
-            nullableDirection = nullableDirection.getClockWise();
-
+            nullableDirection = rotation.rotate(nullableDirection);
         return state.setValue(PropertyHolder.NULLABLE_FACE, NullableDirection.fromDirection(nullableDirection));
     }
 
@@ -79,7 +85,6 @@ public class FramedCollapsibleBlock extends FramedBlock
             if (level.getBlockEntity(pos) instanceof FramedCollapsibleBlockEntity be)
             {
                 Direction nullableDirection = state.getValue(PropertyHolder.NULLABLE_FACE).toDirection().getClockWise();
-                System.out.println(nullableDirection);
                 be.setCollapsedFace(nullableDirection);
                 return super.handleUse(state,level,pos,player,hand,hit);
             }

--- a/src/main/java/xfacthd/framedblocks/common/block/cube/FramedCollapsibleBlock.java
+++ b/src/main/java/xfacthd/framedblocks/common/block/cube/FramedCollapsibleBlock.java
@@ -53,14 +53,21 @@ public class FramedCollapsibleBlock extends FramedBlock
         );
     }
 
-
-
     @Override
     protected @NotNull BlockState rotate(@NotNull BlockState state, @NotNull Rotation rotation) {
         Direction nullableDirection = state.getValue(PropertyHolder.NULLABLE_FACE).toDirection();
         if(nullableDirection != null)
             nullableDirection = rotation.rotate(nullableDirection);
         return state.setValue(PropertyHolder.NULLABLE_FACE, NullableDirection.fromDirection(nullableDirection));
+    }
+
+    @Override
+    public void onBlockStateChange(LevelReader level, BlockPos pos, BlockState oldState, BlockState newState) {
+        super.onBlockStateChange(level, pos, oldState, newState);
+        if (level.getBlockEntity(pos) instanceof FramedCollapsibleBlockEntity be)
+        {
+            be.syncFacingWithBlockState();
+        }
     }
 
     @Override
@@ -76,21 +83,6 @@ public class FramedCollapsibleBlock extends FramedBlock
         return PlacementStateBuilder.of(this, ctx).withWater().build();
     }
 
-    @Override
-    public ItemInteractionResult handleUse(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-        ItemInteractionResult result = super.handleUse(state, level, pos, player, hand, hit);
-        ItemStack heldItem = player.getMainHandItem();
-        if (heldItem.getItem() == FBContent.ITEM_FRAMED_WRENCH.value())
-        {
-            if (level.getBlockEntity(pos) instanceof FramedCollapsibleBlockEntity be)
-            {
-                Direction nullableDirection = state.getValue(PropertyHolder.NULLABLE_FACE).toDirection().getClockWise();
-                be.setCollapsedFace(nullableDirection);
-                return super.handleUse(state,level,pos,player,hand,hit);
-            }
-        }
-        return result;
-    }
 
     @Override
     public boolean handleBlockLeftClick(BlockState state, Level level, BlockPos pos, Player player)

--- a/src/main/java/xfacthd/framedblocks/common/blockentity/special/FramedCollapsibleBlockEntity.java
+++ b/src/main/java/xfacthd/framedblocks/common/blockentity/special/FramedCollapsibleBlockEntity.java
@@ -350,18 +350,22 @@ public class FramedCollapsibleBlockEntity extends FramedBlockEntity implements I
     @Override
     public void onLoad() {
         super.onLoad();
-        syncFacingWithBlockState();
+        //Added for Create compatibility. When dissembling a Create structure it will place the block down
+        // before setting the Tag Compound data it has stored. Due to this we want the Block Entity class to handle the sync on onLoad()
+        // so it will be able to update the Tag Compound data.
+        if(!level().isClientSide)
+        {
+            syncFacingWithBlockState();
+        }
     }
 
     public void syncFacingWithBlockState(){
         NullableDirection nullableDirection = this.getBlockState().getValue(PropertyHolder.NULLABLE_FACE);
-        //Check if the block state and tile entity's collapsedFace are different.
-        //I wanted to use the FramedCollapsibleBlock#onPlace or onBlockStateChanged but for create compatibility due to create writing the tag data after the block was already placed
-        // this was the only other method I could think of that would be able to update collapsedFace without being overwritten with the old tag data.
-        if(!nullableDirection.equals(NullableDirection.fromDirection(this.getCollapsedFace())))
-        {
-            collapsedFace = nullableDirection.toDirection();
-        }
+        collapsedFace = nullableDirection.toDirection();
+        //Updating the block state.
+        level().setBlock(getBlockPos(), getBlockState(), Block.UPDATE_ALL);
+        //Update rendering
+        updateCulling(true, false);
     }
 
     public static byte[] unpackOffsets(int packed)

--- a/src/main/java/xfacthd/framedblocks/common/blockentity/special/FramedCollapsibleBlockEntity.java
+++ b/src/main/java/xfacthd/framedblocks/common/blockentity/special/FramedCollapsibleBlockEntity.java
@@ -343,10 +343,22 @@ public class FramedCollapsibleBlockEntity extends FramedBlockEntity implements I
         super.loadAdditional(nbt, provider);
         packedOffsets = nbt.getInt("offsets");
         int face = nbt.getInt("face");
+
         collapsedFace = face == -1 ? null : Direction.from3DDataValue(face);
     }
 
-
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        NullableDirection nullableDirection = this.getBlockState().getValue(PropertyHolder.NULLABLE_FACE);
+        //Check if the block state and tile entity's collapsedFace are different.
+        //I wanted to use the FramedCollapsibleBlock#onPlace or onBlockStateChanged but for create compatibility due to create writing the tag data after the block was already placed
+        // this was the only other method I could think of that would be able to update collapsedFace without being overwritten with the old tag data.
+        if(!nullableDirection.equals(NullableDirection.fromDirection(this.getCollapsedFace())))
+        {
+            collapsedFace = nullableDirection.toDirection();
+        }
+    }
 
     public static byte[] unpackOffsets(int packed)
     {

--- a/src/main/java/xfacthd/framedblocks/common/blockentity/special/FramedCollapsibleBlockEntity.java
+++ b/src/main/java/xfacthd/framedblocks/common/blockentity/special/FramedCollapsibleBlockEntity.java
@@ -201,6 +201,10 @@ public class FramedCollapsibleBlockEntity extends FramedBlockEntity implements I
         }
     }
 
+    public void setCollapsedFace(@Nullable Direction direction){
+        this.collapsedFace = direction;
+    }
+
     @Nullable
     public Direction getCollapsedFace()
     {

--- a/src/main/java/xfacthd/framedblocks/common/blockentity/special/FramedCollapsibleBlockEntity.java
+++ b/src/main/java/xfacthd/framedblocks/common/blockentity/special/FramedCollapsibleBlockEntity.java
@@ -350,6 +350,10 @@ public class FramedCollapsibleBlockEntity extends FramedBlockEntity implements I
     @Override
     public void onLoad() {
         super.onLoad();
+        syncFacingWithBlockState();
+    }
+
+    public void syncFacingWithBlockState(){
         NullableDirection nullableDirection = this.getBlockState().getValue(PropertyHolder.NULLABLE_FACE);
         //Check if the block state and tile entity's collapsedFace are different.
         //I wanted to use the FramedCollapsibleBlock#onPlace or onBlockStateChanged but for create compatibility due to create writing the tag data after the block was already placed

--- a/src/main/java/xfacthd/framedblocks/common/blockentity/special/FramedCollapsibleCopycatBlockEntity.java
+++ b/src/main/java/xfacthd/framedblocks/common/blockentity/special/FramedCollapsibleCopycatBlockEntity.java
@@ -7,17 +7,21 @@ import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.client.model.data.ModelProperty;
+import xfacthd.framedblocks.FramedBlocks;
 import xfacthd.framedblocks.api.block.blockentity.FramedBlockEntity;
 import xfacthd.framedblocks.api.blueprint.AuxBlueprintData;
 import xfacthd.framedblocks.common.FBContent;
+import xfacthd.framedblocks.common.block.FramedBlock;
 import xfacthd.framedblocks.common.data.PropertyHolder;
 import xfacthd.framedblocks.common.data.component.CollapsibleCopycatBlockData;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 public class FramedCollapsibleCopycatBlockEntity extends FramedBlockEntity implements ICollapsibleCopycatBlockEntity
@@ -228,7 +232,29 @@ public class FramedCollapsibleCopycatBlockEntity extends FramedBlockEntity imple
         updateBeaconOcclusion();
     }
 
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        syncRotationWithBlockState();
+    }
 
+    public void syncRotationWithBlockState() {
+        Rotation rotation = this.getBlockState().getValue(PropertyHolder.ROTATE_MODEL);
+        byte[] newOffsets = new byte[HORIZONTAL_DIRECTIONS.length];
+
+        int i = 0;
+        for (Direction direction : HORIZONTAL_DIRECTIONS)
+        {
+            newOffsets[i] = (byte) getFaceOffset(rotation.rotate(direction));
+            i++;
+        }
+        int j = 0;
+        for(byte offset : newOffsets) {
+            setFaceOffset(Direction.from2DDataValue(j), offset);
+            j++;
+        }
+        FramedBlocks.LOGGER.debug("sync {}", getBlockState().getValue(PropertyHolder.ROTATE_MODEL));
+    }
 
     public static byte[] unpackOffsets(int packed)
     {

--- a/src/main/java/xfacthd/framedblocks/common/data/PropertyHolder.java
+++ b/src/main/java/xfacthd/framedblocks/common/data/PropertyHolder.java
@@ -1,5 +1,8 @@
 package xfacthd.framedblocks.common.data;
 
+import net.minecraft.core.Direction;
+import net.minecraft.data.models.blockstates.VariantProperties;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.properties.*;
 import xfacthd.framedblocks.common.data.property.*;
 
@@ -18,6 +21,7 @@ public final class PropertyHolder
     public static final EnumProperty<ChainType> CHAIN_TYPE = EnumProperty.create("chain", ChainType.class);
     public static final EnumProperty<CornerTubeOrientation> CORNER_TYPE_ORIENTATION = EnumProperty.create("orientation", CornerTubeOrientation.class);
     public static final EnumProperty<PillarConnection> PILLAR_CONNECTION = EnumProperty.create("pillar", PillarConnection.class);
+    public static final EnumProperty<Rotation> ROTATE_MODEL = EnumProperty.create("rotate_model", Rotation.class);
 
     public static final BooleanProperty RIGHT = BooleanProperty.create("right");
     public static final BooleanProperty TOP_HALF = BooleanProperty.create("top_half");

--- a/src/main/java/xfacthd/framedblocks/common/data/PropertyHolder.java
+++ b/src/main/java/xfacthd/framedblocks/common/data/PropertyHolder.java
@@ -1,7 +1,5 @@
 package xfacthd.framedblocks.common.data;
 
-import net.minecraft.core.Direction;
-import net.minecraft.data.models.blockstates.VariantProperties;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.properties.*;
 import xfacthd.framedblocks.common.data.property.*;
@@ -21,6 +19,11 @@ public final class PropertyHolder
     public static final EnumProperty<ChainType> CHAIN_TYPE = EnumProperty.create("chain", ChainType.class);
     public static final EnumProperty<CornerTubeOrientation> CORNER_TYPE_ORIENTATION = EnumProperty.create("orientation", CornerTubeOrientation.class);
     public static final EnumProperty<PillarConnection> PILLAR_CONNECTION = EnumProperty.create("pillar", PillarConnection.class);
+    /**
+     * This Rotation Property is meant to be used to notify the {@link xfacthd.framedblocks.common.blockentity.special.FramedCollapsibleCopycatBlockEntity}
+     * block type is in need of updating the model due to a rotation occurring. Once the block has updated its shape this property should be set to it's default
+     * that being {@link  Rotation#NONE}
+     */
     public static final EnumProperty<Rotation> ROTATE_MODEL = EnumProperty.create("rotate_model", Rotation.class);
 
     public static final BooleanProperty RIGHT = BooleanProperty.create("right");


### PR DESCRIPTION
Added the ability to rotate both FramedCollapsibleCopycatBlock and FramedCollapsibleBlock with the wrench and other mods like Create. Let me know if the code isn't agreeable in its current state, and if you have any pointers on how I can improve it. 

Thank you,
Docvin.
