### PR TITLE
[1.20.1] Fix glowing feature

### DIFF
--- a/src/main/java/xfacthd/framedblocks/api/block/FramedBlockEntity.java
+++ b/src/main/java/xfacthd/framedblocks/api/block/FramedBlockEntity.java
@@ -7,6 +7,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.Connection;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
@@ -665,14 +666,21 @@ public class FramedBlockEntity extends BlockEntity
 
             this.glowing = glowing;
 
-            if (oldLight != getLightValue())
-            {
-                doLightUpdate();
-            }
+            boolean stateChanged = updateDynamicStates(false, true, false);
+            boolean lightChanged = oldLight != getLightValue();
 
             setChanged();
-            //noinspection ConstantConditions
-            level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), Block.UPDATE_ALL);
+            if (lightChanged || stateChanged)
+            {
+                doLightUpdate();
+                scheduleLightUpdate();
+            }
+
+            if (!stateChanged)
+            {
+                //noinspection ConstantConditions
+                level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), Block.UPDATE_ALL);
+            }
         }
     }
 
@@ -753,6 +761,21 @@ public class FramedBlockEntity extends BlockEntity
     {
         //noinspection ConstantConditions
         level.getChunkSource().getLightEngine().checkBlock(worldPosition);
+    }
+
+    protected final void scheduleLightUpdate()
+    {
+        if (level instanceof ServerLevel serverLevel)
+        {
+            serverLevel.getServer().execute(() ->
+            {
+                if (!isRemoved() && level != null && level.hasChunkAt(worldPosition))
+                {
+                    doLightUpdate();
+                    level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), Block.UPDATE_ALL);
+                }
+            });
+        }
     }
 
     public IFramedBlock getBlock()
@@ -862,9 +885,19 @@ public class FramedBlockEntity extends BlockEntity
     public void onLoad()
     {
         //noinspection ConstantConditions
-        if (!level.isClientSide() && recheckStates)
+        if (!level.isClientSide())
         {
-            checkCamoSolid();
+            boolean stateMatchesLight = getBlockState().getValue(FramedProperties.GLOWING) == (getLightValue() > 0);
+            if (recheckStates || !stateMatchesLight)
+            {
+                checkCamoSolid();
+            }
+
+            if (getLightValue() > 0 || getBlockState().getValue(FramedProperties.GLOWING))
+            {
+                doLightUpdate();
+                scheduleLightUpdate();
+            }
         }
         super.onLoad();
     }

--- a/src/main/java/xfacthd/framedblocks/api/block/IFramedBlock.java
+++ b/src/main/java/xfacthd/framedblocks/api/block/IFramedBlock.java
@@ -12,6 +12,7 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.*;
@@ -66,6 +67,8 @@ public interface IFramedBlock extends EntityBlock, IForgeBlock
                 .instrument(NoteBlockInstrument.BASS)
                 .strength(2F)
                 .sound(SoundType.WOOD)
+                .lightLevel(IFramedBlock::getFramedBlockStateLightEmission)
+                .isValidSpawn(IFramedBlock::isValidSpawnOnFramedBlock)
                 .isViewBlocking(IFramedBlock::isBlockSuffocating)
                 .isSuffocating(IFramedBlock::isBlockSuffocating);
 
@@ -80,6 +83,29 @@ public interface IFramedBlock extends EntityBlock, IForgeBlock
     private static boolean isBlockSuffocating(BlockState state, BlockGetter level, BlockPos pos)
     {
         return ((IFramedBlock) state.getBlock()).isSuffocating(state, level, pos);
+    }
+
+    private static int getFramedBlockStateLightEmission(BlockState state)
+    {
+        // The light engine and section caches may query the vanilla state light value without
+        // access to the block entity. Persisting the glowstone emission in the BlockState keeps
+        // glowing framed blocks real server-side light sources across chunk reloads. Exact
+        // camo light values are still handled by the dynamic getLightEmission override below
+        // whenever the block entity is available.
+        return Utils.tryGetValue(state, FramedProperties.GLOWING, false)
+                ? FramedBlocksAPI.getInstance().getGlowstoneLightLevel()
+                : 0;
+    }
+
+    private static boolean isValidSpawnOnFramedBlock(
+            BlockState state, BlockGetter level, BlockPos pos, EntityType<?> entityType
+    )
+    {
+        if (Utils.tryGetValue(state, FramedProperties.GLOWING, false))
+        {
+            return false;
+        }
+        return state.isFaceSturdy(level, pos, Direction.UP);
     }
 
     default BlockItem createBlockItem()
@@ -186,7 +212,11 @@ public interface IFramedBlock extends EntityBlock, IForgeBlock
         {
             return be.getLightValue();
         }
-        return 0;
+
+        // During chunk loading/light rebuilds, the light engine can ask for this value before the
+        // block entity is available. GLOWING is saved in the BlockState, so use the configured
+        // glowstone light level as a safe fallback instead of returning 0 and leaving the chunk dark.
+        return FramedBlocksAPI.getInstance().getGlowstoneLightLevel();
     }
 
     default boolean playBreakSound(BlockState state, Level level, BlockPos pos)


### PR DESCRIPTION
Fixed glowing feature, it existed only via the block entity/dynamic Forge light path, not as a real blockstate/lightLevel so Minecrafts reload/chunk light engine didn’t reliably treat it as an actual light source.